### PR TITLE
Fix error when `--filter` is empty

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,5 +7,5 @@ export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 [[ -n "${INPUT_FLAGS}" ]] && set -- "$@" ${INPUT_FLAGS}
 [[ -n "${INPUT_FILTER}" ]] && set -- "$@" --filter="${INPUT_FILTER}"
 
-cpplint "$@" ${INPUT_TARGETS} 2>&1 | \
+cpplint "$@" ${INPUT_TARGETS} 2>&1 \
     | reviewdog -efm="%f:%l: %m" -name="cpplint" -reporter="${INPUT_REPORTER}" -level="${INPUT_LEVEL}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,5 +4,8 @@ cd "${GITHUB_WORKSPACE}" || exit
 
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
-cpplint ${INPUT_FLAGS} --filter="${INPUT_FILTER}" ${INPUT_TARGETS} 2>&1 \
+[[ -n "${INPUT_FLAGS}" ]] && set -- "$@" ${INPUT_FLAGS}
+[[ -n "${INPUT_FILTER}" ]] && set -- "$@" --filter="${INPUT_FILTER}"
+
+cpplint "$@" ${INPUT_TARGETS} 2>&1 | \
     | reviewdog -efm="%f:%l: %m" -name="cpplint" -reporter="${INPUT_REPORTER}" -level="${INPUT_LEVEL}"


### PR DESCRIPTION
If action argument `inputs.filter` was not set, then this would error since `--filter` must be non-empty if used:

```sh
$ cpplint --filter=${INPUT_FILTER} --recursive .
```

Changed the entrypoint script to only add these options when certain `INPUT_*` variables are set