### PR TITLE
Add reviewdog_flags to action

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Default is `error`.
 Reporter of reviewdog command [github-pr-check,github-pr-review].
 Default is `github-pr-check`.
 
+### `reviewdog-flags`
+Additional reviewdog flags.
+Default is `''`.
+
 ### `flags`
 
 Optional. List of arguments to send to cpplint.
@@ -34,7 +38,7 @@ Default is `--extensions=h,hpp,c,cpp,cc,cu,hh,ipp`.
 ### `filter`
 
 Optional. List of filter arguments to send to cpplint.
-Default is `-build/include_order`.
+Default is `''`.
 
 ### `targets`
 

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,11 @@ inputs:
       Reporter of reviewdog command [github-pr-check,github-pr-review].
       Default is 'github-pr-check'.
     default: 'github-pr-check'
+  reviewdog_flags:
+    description: |
+      Additional reviewdog flags.
+      Default is ''.
+    default: ''
   flags:
     description: |
       List of arguments to send to cpplint.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,4 +5,4 @@ cd "${GITHUB_WORKSPACE}" || exit
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
 cpplint ${INPUT_FLAGS} --filter="${INPUT_FILTER}" ${INPUT_TARGETS} 2>&1 \
-    | reviewdog -efm="%f:%l: %m" -name="cpplint" -reporter="${INPUT_REPORTER}" -level="${INPUT_LEVEL}"
+    | reviewdog -efm="%f:%l: %m" -name="cpplint" -reporter="${INPUT_REPORTER}" -level="${INPUT_LEVEL}" "${INPUT_REVIEWDOG_FLAGS}"


### PR DESCRIPTION
Adding `inputs.reviewdog_flags` as inputs to `reviewdog ${INPUTS_REVIEWDOG_FLAGS}`.

This exists in other actions like [action-eslint](https://github.com/reviewdog/action-eslint/action.yml).